### PR TITLE
added platformio library manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,44 @@ MatrixVoiceAudioServerNoOTA/sdkconfig
 MatrixVoiceAudioServerNoOTA/build
 *.bin
 OTABuilder/build
-.vscode/
+.vscode/build
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Vim backups
+*.swp
+
+# travis
+.travis.yml
+
+# PlatformIO work files
+.pio
+.pioenvs
+.piolibdeps
+*tags*
+
+

--- a/MATRIXVoiceOTA/MATRIXVoiceOTA.cpp
+++ b/MATRIXVoiceOTA/MATRIXVoiceOTA.cpp
@@ -54,7 +54,6 @@ void MATRIXVoiceOTA::setup() {
 
 void MATRIXVoiceOTA::loop() {
     ArduinoOTA.handle();
-    delay(1000);  
 }
 
 void MATRIXVoiceOTA::setBaud(int baud) {

--- a/library.json
+++ b/library.json
@@ -1,0 +1,28 @@
+{
+  "name": "MATRIX Voice ESP32 Arduino OTA",
+  "keywords": "OTA, drivers, matrixvoice, everloop, mic, micarray, hal",
+  "description": "Program your Matrix Voice ESP32 through the Arduino IDE",
+  "homepage": "https://www.matrix.one/products/voice",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hpsaturn/esp32-arduino-ota.git"
+  },
+  "version": "0.15.0",
+  "authors": [
+    {
+      "name": "Matrix One",
+      "url": "https://www.matrix.one"
+    },
+    {
+      "name": "@hpsaturn",
+      "email": "hpsaturn@gmail.com",
+      "url": "http://hpsaturn.com",
+      "maintainer": true
+    }
+  ],
+  "build":{
+    "srcDir":"MATRIXVoiceOTA"
+  },
+  "frameworks": "arduino",
+  "platforms": "*"
+}

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
   "version": "0.15.0",
   "authors": [
     {
-      "name": "Matrix One",
+      "name": "MATRIX Labs",
       "url": "https://www.matrix.one"
     },
     {

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
-  "name": "MATRIX Voice ESP32 Arduino OTA",
-  "keywords": "OTA, drivers, matrixvoice, everloop, mic, micarray, hal",
-  "description": "Program your Matrix Voice ESP32 through the Arduino IDE",
+  "name": "MATRIXVoiceESP32ArduinoOTA",
+  "keywords": "arduino, OTA, drivers, matrixvoice, everloop, mic, micarray, hal",
+  "description": "Program your Matrix Voice ESP32 through the Arduino IDE via OTA updates",
   "homepage": "https://www.matrix.one/products/voice",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added [PlatformIO](https://platformio.org/) library manager support. PlatformIO is an open source ecosystem for IoT development, with this registry we have support for build Matrixio ESP32 OTA library with it.

Please validate or comment the "authors" section and Matrixone urls, etc.